### PR TITLE
Query string and site resolving fixes, exception trapping

### DIFF
--- a/website/EventHandlers/RedirectMapCacheClearer.cs
+++ b/website/EventHandlers/RedirectMapCacheClearer.cs
@@ -18,7 +18,6 @@ namespace LiquidSC.Foundation.RedirectManager.EventHandlers
         {
             Assert.ArgumentNotNull(sender, "sender");
             Assert.ArgumentNotNull(args, "args");
-            Log.Info("RedirectMapCacheClearer clearer triggered by event: " + ((Sitecore.Events.SitecoreEventArgs)args).EventName, this);
             Log.Info("RedirectMapCacheClearer clearing redirect map cache.", this);
             RedirectsRepository.Reset();
             Log.Info("RedirectMapCacheClearer done.", this);

--- a/website/Pipelines.Base/RedirectResolverBase.cs
+++ b/website/Pipelines.Base/RedirectResolverBase.cs
@@ -371,7 +371,7 @@ namespace LiquidSC.Foundation.RedirectManager.Pipelines.Base
                         // GetItemUrl appears to produce double trailing slashes for cross-site links: clean that up
                         redirectUrl = new UriBuilder(redirectUrl)
                         {
-                            Path = new Uri(redirectUrl).PathAndQuery.Replace("//", "/"),
+                            Path = this.GetPathAndQuery(redirectUrl).Replace("//", "/"),
                             Query = redirectLinkField.QueryString.TrimStart('?'),
                             Fragment = redirectLinkField.Anchor.TrimStart('#')
                         }.Uri.AbsoluteUri;
@@ -396,6 +396,11 @@ namespace LiquidSC.Foundation.RedirectManager.Pipelines.Base
             }
 
             return redirectUrl;
+        }
+
+        protected string GetPathAndQuery(string redirectUrl)
+        {
+            return new Uri(redirectUrl).PathAndQuery;
         }
 
         private static bool IsFromCurrentSite(Item item)

--- a/website/Pipelines.Base/RedirectResolverBase.cs
+++ b/website/Pipelines.Base/RedirectResolverBase.cs
@@ -448,7 +448,7 @@ namespace LiquidSC.Foundation.RedirectManager.Pipelines.Base
             context.Response.Flush();
 
             // Complete the request rather than ending the response to avoid System.Threading.ThreadAbortException on redirecting
-            HttpContext.Current.ApplicationInstance.CompleteRequest();
+            context.ApplicationInstance.CompleteRequest();
         }
         
         protected virtual void Redirect302(HttpContext context, string url)

--- a/website/Pipelines.Base/RedirectResolverBase.cs
+++ b/website/Pipelines.Base/RedirectResolverBase.cs
@@ -366,7 +366,6 @@ namespace LiquidSC.Foundation.RedirectManager.Pipelines.Base
                         if (IsFromCurrentSite(redirectLinkField.TargetItem))
                         {
                             redirectUrl = LinkManager.GetItemUrl(redirectLinkField.TargetItem, urlOptions);
-                            Sitecore.Diagnostics.Log.Info($"Is from current site: {redirectUrl}.", this);
                         }
                         else
                         {

--- a/website/Pipelines.Base/RedirectResolverBase.cs
+++ b/website/Pipelines.Base/RedirectResolverBase.cs
@@ -287,45 +287,37 @@ namespace LiquidSC.Foundation.RedirectManager.Pipelines.Base
             return redirectQueryString;
         }
 
-        protected virtual void GetPreservedQueryString(Redirect resolvedMapping)
+        protected virtual string GetTargetUrlWithPreservedQueryString(Redirect resolvedMapping)
         {
-            // Prevent query string from being repeatedly (re)appended
-            resolvedMapping.Target = Regex.Split(resolvedMapping.Target, @"[\?\#]")[0];
-            if (resolvedMapping.PreserveQueryString && Context.Request.QueryString.Count > 0)
+            var targetUrl = resolvedMapping.Target;
+            if (!resolvedMapping.PreserveQueryString || Context.Request.QueryString.Count <= 0)
             {
-                var sourceQueryStringList = new List<string>();
-
-                //append all source parameters to list
-                foreach (String key in Context.Request.QueryString)
-                {
-                    string parameter = key;
-
-                    if (!String.IsNullOrWhiteSpace(Sitecore.Context.Request.QueryString[key]))
-                    {
-                        parameter = key + "=" + Sitecore.Context.Request.QueryString[key];
-                    }
-
-                    sourceQueryStringList.Add(parameter);
-                }
-
-                if (resolvedMapping.RedirectItem.Fields[Constants.TargetFieldName] != null)
-                {
-                    LinkField lf = resolvedMapping.RedirectItem.Fields[Constants.TargetFieldName];
-
-                    if (lf != null && !String.IsNullOrWhiteSpace(lf.QueryString))
-                    {
-                        resolvedMapping.Target = string.Concat(resolvedMapping.Target, StringUtil.EnsurePrefix('?', lf.QueryString), string.Concat("&", String.Join("&", sourceQueryStringList)));
-                    }
-                    else
-                    {
-                        resolvedMapping.Target = string.Concat(resolvedMapping.Target, string.Concat("?", String.Join("&", sourceQueryStringList)));
-                    }
-                }
-                else
-                {
-                    resolvedMapping.Target = string.Concat(resolvedMapping.Target, string.Concat("?", String.Join("&", sourceQueryStringList)));
-                }
+                return targetUrl;
             }
+
+            var sourceQueryStringList = new List<string>();
+
+            // Append all source parameters to list
+            foreach (string key in Context.Request.QueryString)
+            {
+                var parameter = key;
+                if (!string.IsNullOrWhiteSpace(Context.Request.QueryString[key]))
+                {
+                    parameter = key + "=" + HttpUtility.UrlEncode(Context.Request.QueryString[key]);
+                }
+
+                sourceQueryStringList.Add(parameter);
+            }
+
+            var targetUrlParts = targetUrl.Split('#');
+            var targetUrlNoAnchor = targetUrlParts[0];
+            targetUrl = string.Concat(targetUrlNoAnchor, string.Concat(targetUrlNoAnchor.IndexOf('?') >= 0 ? "&" : "?", string.Join("&", sourceQueryStringList)));
+            if (targetUrlParts.Length > 1)
+            {
+                targetUrl = $"{targetUrl}#{targetUrlParts[1]}";
+            }
+
+            return targetUrl;
         }
 
         protected virtual string GetRedirectUrl(Item redirectItem)
@@ -376,11 +368,12 @@ namespace LiquidSC.Foundation.RedirectManager.Pipelines.Base
                             }
                         }
 
-                        //getitemurl appears to produce double trailing slashes for cross site links, clean that up
+                        // GetItemUrl appears to produce double trailing slashes for cross-site links: clean that up
                         redirectUrl = new UriBuilder(redirectUrl)
                         {
                             Path = new Uri(redirectUrl).PathAndQuery.Replace("//", "/"),
-                            Query = redirectLinkField.QueryString
+                            Query = redirectLinkField.QueryString.TrimStart('?'),
+                            Fragment = redirectLinkField.Anchor.TrimStart('#')
                         }.Uri.AbsoluteUri;
                     }
                     else if (redirectLinkField.IsMediaLink)

--- a/website/Pipelines.HttpRequest/ItemRedirect/ItemRedirectResolver.cs
+++ b/website/Pipelines.HttpRequest/ItemRedirect/ItemRedirectResolver.cs
@@ -59,7 +59,7 @@ namespace LiquidSC.Foundation.RedirectManager.Pipelines.HttpRequest
                     }
                     else if (resolvedMapping.RedirectType == RedirectType.ServerTransfer)
                     {
-                        HttpContext.Current.Server.TransferRequest(targetUrl);
+                        HttpContext.Current.Server.TransferRequest(this.GetPathAndQuery(targetUrl));
                     }
                     else
                     {

--- a/website/Pipelines.HttpRequest/ItemRedirect/ItemRedirectResolver.cs
+++ b/website/Pipelines.HttpRequest/ItemRedirect/ItemRedirectResolver.cs
@@ -197,10 +197,17 @@ namespace LiquidSC.Foundation.RedirectManager.Pipelines.HttpRequest
 
         public static string GetItemIdByPath(string path)
         {
-            var Item = Sitecore.Context.Database.SelectSingleItem(path);
-            if (Item != null)
+            try
             {
-                return Item.ID.ToString();
+                var item = Context.Database.SelectSingleItem(path);
+                if (item != null)
+                {
+                    return item.ID.ToString();
+                }
+            }
+            catch
+            {
+                return string.Empty;
             }
 
             return string.Empty;

--- a/website/Pipelines.HttpRequest/ItemRedirect/ItemRedirectResolver.cs
+++ b/website/Pipelines.HttpRequest/ItemRedirect/ItemRedirectResolver.cs
@@ -51,11 +51,11 @@ namespace LiquidSC.Foundation.RedirectManager.Pipelines.HttpRequest
 
                     if (resolvedMapping.RedirectType == RedirectType.Redirect301)
                     {
-                        this.Redirect301(HttpContext.Current.Response, resolvedMapping.Target);
+                        this.Redirect301(HttpContext.Current, resolvedMapping.Target);
                     }
                     else if (resolvedMapping.RedirectType == RedirectType.Redirect302)
                     {
-                        HttpContext.Current.Response.Redirect(resolvedMapping.Target, true);
+                        this.Redirect302(HttpContext.Current, resolvedMapping.Target);
                     }
                     else if (resolvedMapping.RedirectType == RedirectType.ServerTransfer)
                     {
@@ -64,7 +64,7 @@ namespace LiquidSC.Foundation.RedirectManager.Pipelines.HttpRequest
                     //default to 302
                     else
                     {
-                        HttpContext.Current.Response.Redirect(resolvedMapping.Target, true);
+                        this.Redirect302(HttpContext.Current, resolvedMapping.Target);
                     }
 
                     args.AbortPipeline();

--- a/website/Pipelines.HttpRequest/ItemRedirect/ItemRedirectResolver.cs
+++ b/website/Pipelines.HttpRequest/ItemRedirect/ItemRedirectResolver.cs
@@ -3,6 +3,7 @@ using Sitecore.Data.Items;
 using LiquidSC.Foundation.RedirectManager.Extensions;
 using LiquidSC.Foundation.RedirectManager.Pipelines.Base;
 using Sitecore.Pipelines.HttpRequest;
+using Sitecore.SecurityModel;
 using Sitecore.StringExtensions;
 using System;
 using System.Collections.Generic;
@@ -135,10 +136,14 @@ namespace LiquidSC.Foundation.RedirectManager.Pipelines.HttpRequest
 
                         Enum.TryParse<RedirectType>(redirectItem[Templates.RedirectSettings.Fields.RedirectType], out redirectType);
 
-                        var sourceItemId = this.GetSourceItemID(redirectItem);
+                        string sourceItemId, targetUrl;
+                        using (new SecurityDisabler())
+                        {
+                            sourceItemId = this.GetSourceItemID(redirectItem);
 
-                        // Get the resolved target URL (this already includes any target query string) 
-                        var targetUrl = this.GetRedirectUrl(redirectItem);
+                            // Get the resolved target URL (this already includes any target query string) 
+                            targetUrl = this.GetRedirectUrl(redirectItem);
+                        }
                         
                         if (!string.IsNullOrWhiteSpace(targetUrl) && !string.IsNullOrWhiteSpace(sourceItemId))
                         {

--- a/website/Pipelines.HttpRequest/ItemRedirect/ItemRedirectResolver.cs
+++ b/website/Pipelines.HttpRequest/ItemRedirect/ItemRedirectResolver.cs
@@ -20,7 +20,7 @@ namespace LiquidSC.Foundation.RedirectManager.Pipelines.HttpRequest
 
         public override void ProcessRequest(HttpRequestArgs args)
         {
-            //if the source request url isn't aassociated with an item, skip this processor
+            //if the source request url isn't associated with an item, skip this processor
             if (Context.Item == null)
                 return;
 
@@ -46,25 +46,24 @@ namespace LiquidSC.Foundation.RedirectManager.Pipelines.HttpRequest
             {
                 if (!resolvedMapping.Target.IsNullOrEmpty())
                 {
-                    //if we are preserving the incoming query string, append it now
-                    GetPreservedQueryString(resolvedMapping);
-
+                    // If we are preserving the incoming query string, append it now
+                    var targetUrl = this.GetTargetUrlWithPreservedQueryString(resolvedMapping);
                     if (resolvedMapping.RedirectType == RedirectType.Redirect301)
                     {
-                        this.Redirect301(HttpContext.Current, resolvedMapping.Target);
+                        this.Redirect301(HttpContext.Current, targetUrl);
                     }
                     else if (resolvedMapping.RedirectType == RedirectType.Redirect302)
                     {
-                        this.Redirect302(HttpContext.Current, resolvedMapping.Target);
+                        this.Redirect302(HttpContext.Current, targetUrl);
                     }
                     else if (resolvedMapping.RedirectType == RedirectType.ServerTransfer)
                     {
-                        HttpContext.Current.Server.TransferRequest(resolvedMapping.Target);
+                        HttpContext.Current.Server.TransferRequest(targetUrl);
                     }
-                    //default to 302
                     else
                     {
-                        this.Redirect302(HttpContext.Current, resolvedMapping.Target);
+                        // Default to 302
+                        this.Redirect302(HttpContext.Current, targetUrl);
                     }
 
                     args.AbortPipeline();
@@ -138,19 +137,11 @@ namespace LiquidSC.Foundation.RedirectManager.Pipelines.HttpRequest
 
                         var sourceItemId = this.GetSourceItemID(redirectItem);
 
-                        //get the resolved target url
+                        // Get the resolved target URL (this already includes any target query string) 
                         var targetUrl = this.GetRedirectUrl(redirectItem);
-
-                        //get the target query string
-                        var targetQueryString = GetTargetQueryString(redirectItem);
-
-                        if (!string.IsNullOrWhiteSpace(targetUrl)
-                            && !string.IsNullOrWhiteSpace(sourceItemId)
-                            )
+                        
+                        if (!string.IsNullOrWhiteSpace(targetUrl) && !string.IsNullOrWhiteSpace(sourceItemId))
                         {
-                            //if there is a query string property on the link field (only on internal type fields), append it to the target url
-                            targetUrl = string.Concat(targetUrl, (string.IsNullOrWhiteSpace(targetQueryString) ? "" : string.Concat("?", targetQueryString)));
-
                             var redirect = new ItemRedirect
                             {
                                 RedirectItem = redirectItem,

--- a/website/Pipelines.HttpRequest/PathRedirect/PathRedirectResolver.cs
+++ b/website/Pipelines.HttpRequest/PathRedirect/PathRedirectResolver.cs
@@ -61,7 +61,7 @@ namespace LiquidSC.Foundation.RedirectManager.Pipelines.HttpRequest
                     }
                     else if (resolvedMapping.RedirectType == RedirectType.ServerTransfer)
                     {
-                        HttpContext.Current.Server.TransferRequest(targetUrl);
+                        HttpContext.Current.Server.TransferRequest(this.GetPathAndQuery(targetUrl));
                     }
                     else
                     {

--- a/website/Pipelines.HttpRequest/PathRedirect/PathRedirectResolver.cs
+++ b/website/Pipelines.HttpRequest/PathRedirect/PathRedirectResolver.cs
@@ -48,25 +48,24 @@ namespace LiquidSC.Foundation.RedirectManager.Pipelines.HttpRequest
             {
                 if (!resolvedMapping.Target.IsNullOrEmpty())
                 {
-                    //if we are preserving the incoming query string, append it now
-                    GetPreservedQueryString(resolvedMapping);
-
+                    // If we are preserving the incoming query string, append it now
+                    var targetUrl = this.GetTargetUrlWithPreservedQueryString(resolvedMapping);
                     if (resolvedMapping.RedirectType == RedirectType.Redirect301)
                     {
-                        this.Redirect301(HttpContext.Current, resolvedMapping.Target);
+                        this.Redirect301(HttpContext.Current, targetUrl);
                     }
                     else if (resolvedMapping.RedirectType == RedirectType.Redirect302)
                     {
-                        this.Redirect302(HttpContext.Current, resolvedMapping.Target);
+                        this.Redirect302(HttpContext.Current, targetUrl);
                     }
                     else if (resolvedMapping.RedirectType == RedirectType.ServerTransfer)
                     {
-                        HttpContext.Current.Server.TransferRequest(resolvedMapping.Target);
+                        HttpContext.Current.Server.TransferRequest(targetUrl);
                     }
-                    //default to 302
                     else
                     {
-                        this.Redirect302(HttpContext.Current, resolvedMapping.Target);
+                        // Default to 302
+                        this.Redirect302(HttpContext.Current, targetUrl);
                     }
 
                     args.AbortPipeline();

--- a/website/Pipelines.HttpRequest/PathRedirect/PathRedirectResolver.cs
+++ b/website/Pipelines.HttpRequest/PathRedirect/PathRedirectResolver.cs
@@ -2,6 +2,7 @@ using Sitecore.Data.Items;
 using LiquidSC.Foundation.RedirectManager.Extensions;
 using LiquidSC.Foundation.RedirectManager.Pipelines.Base;
 using Sitecore.Pipelines.HttpRequest;
+using Sitecore.SecurityModel;
 using Sitecore.StringExtensions;
 using System;
 using System.Collections.Generic;
@@ -127,8 +128,12 @@ namespace LiquidSC.Foundation.RedirectManager.Pipelines.HttpRequest
                         //get the source raw value
                         var source = this.GetSourceFieldValue(redirectItem);
 
-                        //get the resolved target url
-                        var targetUrl = this.GetRedirectUrl(redirectItem);
+                        string targetUrl;
+                        using (new SecurityDisabler())
+                        {
+                            // Get the resolved target URL
+                            targetUrl = this.GetRedirectUrl(redirectItem);
+                        }
 
                         if (!string.IsNullOrWhiteSpace(targetUrl)
                             && !string.IsNullOrWhiteSpace(source)

--- a/website/Pipelines.HttpRequest/PathRedirect/PathRedirectResolver.cs
+++ b/website/Pipelines.HttpRequest/PathRedirect/PathRedirectResolver.cs
@@ -53,11 +53,11 @@ namespace LiquidSC.Foundation.RedirectManager.Pipelines.HttpRequest
 
                     if (resolvedMapping.RedirectType == RedirectType.Redirect301)
                     {
-                        this.Redirect301(HttpContext.Current.Response, resolvedMapping.Target);
+                        this.Redirect301(HttpContext.Current, resolvedMapping.Target);
                     }
                     else if (resolvedMapping.RedirectType == RedirectType.Redirect302)
                     {
-                        HttpContext.Current.Response.Redirect(resolvedMapping.Target, true);
+                        this.Redirect302(HttpContext.Current, resolvedMapping.Target);
                     }
                     else if (resolvedMapping.RedirectType == RedirectType.ServerTransfer)
                     {
@@ -66,7 +66,7 @@ namespace LiquidSC.Foundation.RedirectManager.Pipelines.HttpRequest
                     //default to 302
                     else
                     {
-                        HttpContext.Current.Response.Redirect(resolvedMapping.Target, true);
+                        this.Redirect302(HttpContext.Current, resolvedMapping.Target);
                     }
 
                     args.AbortPipeline();

--- a/website/Pipelines.HttpRequest/RedirectMap/RedirectMapResolver.cs
+++ b/website/Pipelines.HttpRequest/RedirectMap/RedirectMapResolver.cs
@@ -58,7 +58,7 @@ namespace LiquidSC.Foundation.RedirectManager.Pipelines.HttpRequest
                 }
                 else if (resolvedMapping.RedirectType == RedirectType.ServerTransfer)
                 {
-                    HttpContext.Current.Server.TransferRequest(targetUrl);
+                    HttpContext.Current.Server.TransferRequest(this.GetPathAndQuery(targetUrl));
                 }
                 else
                 {

--- a/website/Pipelines.HttpRequest/RedirectMap/RedirectMapResolver.cs
+++ b/website/Pipelines.HttpRequest/RedirectMap/RedirectMapResolver.cs
@@ -50,11 +50,11 @@ namespace LiquidSC.Foundation.RedirectManager.Pipelines.HttpRequest
                 string targetUrl = this.GetTargetUrl(resolvedMapping, requestedPath);
                 if (resolvedMapping.RedirectType == RedirectType.Redirect301)
                 {
-                    this.Redirect301(HttpContext.Current.Response, targetUrl);
+                    this.Redirect301(HttpContext.Current, targetUrl);
                 }
                 else if (resolvedMapping.RedirectType == RedirectType.Redirect302)
                 {
-                    HttpContext.Current.Response.Redirect(targetUrl, true);
+                    this.Redirect302(HttpContext.Current, targetUrl);
                 }
                 else if (resolvedMapping.RedirectType == RedirectType.ServerTransfer)
                 {
@@ -62,7 +62,7 @@ namespace LiquidSC.Foundation.RedirectManager.Pipelines.HttpRequest
                 }
                 else
                 {
-                    HttpContext.Current.Response.Redirect(targetUrl, true);
+                    this.Redirect302(HttpContext.Current, targetUrl);
                 }
             }
         }


### PR DESCRIPTION
- Fixed query string infinite (re)appending by removing duplicate code and preventing source query string from being cached with redirect;
- Explicitly encoded source query string parameters;
- Catered for target item anchors;
- Properly resolved links to items on different sites;
- Enabled redirects between authenticated pages by using Sitecore `SecurityDisabler` to retrieve redirect source and target items that cannot be accessed by anonymous users;
- Prevented `System.Threading.ThreadAbortException` on 301 & 302 redirects;
- Removed log line throwing an error on CD servers owing to invalid cast on `publish:end:remote`;
- Fixed server transfers by using the target relative URL;
- Fixed an issue where `Database.SelectSingleItem` could throw an exception in some circumstances.